### PR TITLE
Fix player jitteriness

### DIFF
--- a/src/client/game.ts
+++ b/src/client/game.ts
@@ -147,6 +147,14 @@ export class Game {
         if (playerWithId.isShielded) safeGetElementById("health").style.background = "cyan";
         else safeGetElementById("health").style.background = "rgb(201, 0, 0)";
 
+        this.players.forEach((player) => player.update(elapsedTime));
+
+        this.blasts.forEach((blast) => blast.update(elapsedTime));
+        this.blasts = this.blasts.filter((blast) => blast.opacity > 0);
+
+        this.arrows.forEach((arrow) => arrow.update(elapsedTime));
+        this.arrows = this.arrows.filter((arrow) => arrow.inGround === false);
+
         // Collision detection with other players or platforms
         this.players.forEach((player1) => {
             this.players.forEach((player2) => {
@@ -169,14 +177,6 @@ export class Game {
                 //arrow.checkCollisionWithRectangularObject(platform, elapsedTime * 2);
             });
         });
-
-        this.players.forEach((player) => player.update(elapsedTime));
-
-        this.blasts.forEach((blast) => blast.update(elapsedTime));
-        this.blasts = this.blasts.filter((blast) => blast.opacity > 0);
-
-        this.arrows.forEach((arrow) => arrow.update(elapsedTime));
-        this.arrows = this.arrows.filter((arrow) => arrow.inGround === false);
 
         this.render();
     }

--- a/src/server/game.ts
+++ b/src/server/game.ts
@@ -4,7 +4,7 @@ import { ServerArrow } from "./arrow";
 import { getDefaultPlatformList, ServerPlatform } from "./platform";
 import { ServerPlayer } from "./player";
 import * as wsWebsocket from "ws";
-import { ClientMessage, InfoMessage, PlayerLeavingMessage } from "../api/message";
+import { ClientMessage, InfoMessage, PlayerLeavingMessage, ServerMessage } from "../api/message";
 import { Vector } from "../vector";
 import { Config } from "../config";
 
@@ -16,7 +16,7 @@ export class Game {
     private blasts: ServerBlast[] = [];
     private arrows: ServerArrow[] = [];
     private readonly platforms: ServerPlatform[] = getDefaultPlatformList(this.config);
-    public readonly clientMap: Record<number, wsWebsocket> = {};
+    public readonly clientMap: Record<number, (message: ServerMessage) => void> = {};
 
     constructor(public readonly config: Config) {}
 
@@ -55,8 +55,8 @@ export class Game {
             type: "info",
             info: this.allInfo(),
         };
-        Object.values(this.clientMap).forEach((client) => {
-            client.send(JSON.stringify(data));
+        Object.values(this.clientMap).forEach((sendFunction) => {
+            sendFunction(data);
         });
     }
 
@@ -115,8 +115,8 @@ export class Game {
             type: "playerLeaving",
             id,
         };
-        Object.values(this.clientMap).forEach((ws) => {
-            ws.send(JSON.stringify(leavingMessage));
+        Object.values(this.clientMap).forEach((sendFunction) => {
+            sendFunction(leavingMessage);
         });
     }
 

--- a/src/server/game.ts
+++ b/src/server/game.ts
@@ -61,6 +61,16 @@ export class Game {
     }
 
     public update(elapsedTime: number) {
+        this.players.forEach((player) => player.update(elapsedTime));
+        // Collision detection with other players or platforms
+        this.blasts.forEach((blast) => blast.update(elapsedTime));
+        this.blasts = this.blasts.filter((blast) => blast.opacity > 0);
+
+        this.arrows.forEach((arrow) => arrow.update(elapsedTime));
+        this.arrows = this.arrows.filter((arrow) => arrow.inGround === false);
+
+        this.platforms.forEach((platform) => platform.update());
+
         this.players.forEach((player1) => {
             this.players.forEach((player2) => {
                 if (player1 !== player2 && player2.isDead === false && player1.isDead === false) {
@@ -82,16 +92,6 @@ export class Game {
                 //arrow.checkCollisionWithRectangularObject(platform, elapsedTime * 2);
             });
         });
-
-        this.players.forEach((player) => player.update(elapsedTime));
-        // Collision detection with other players or platforms
-        this.blasts.forEach((blast) => blast.update(elapsedTime));
-        this.blasts = this.blasts.filter((blast) => blast.opacity > 0);
-
-        this.arrows.forEach((arrow) => arrow.update(elapsedTime));
-        this.arrows = this.arrows.filter((arrow) => arrow.inGround === false);
-
-        this.platforms.forEach((platform) => platform.update());
     }
 
     public newPlayer(id: number, color: string) {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -5,7 +5,7 @@ import * as bodyParser from "body-parser";
 import * as expressWs from "express-ws";
 import { defaultConfig } from "../config";
 import { JoinRequest, JoinResponse } from "../api/join";
-import { ClientMessage } from "../api/message";
+import { ClientMessage, ServerMessage } from "../api/message";
 
 const game = new Game(defaultConfig);
 game.start();
@@ -34,7 +34,13 @@ app.post("/join", (request, response) => {
 
 app.ws("/:id", (ws, request) => {
     const clientId = parseInt(request.params.id);
-    game.clientMap[clientId] = ws;
+    game.clientMap[clientId] = (message: ServerMessage) => {
+        if (ws.OPEN) {
+            ws.send(JSON.stringify(message));
+        } else {
+            console.log("Tried to send to a closed websocket");
+        }
+    };
 
     ws.on("message", (msg) => {
         const data: ClientMessage = JSON.parse(msg.toString());


### PR DESCRIPTION
The jitteriness was caused by the collision detection happening _before_ the player update was happening, so the player would sink slightly into the platform due to gravity. That information was sent to the client and the client was updated and rendered before the collision detection that would push the player back up. 